### PR TITLE
Fix left sidebar close error

### DIFF
--- a/src/components/Layout/TestLayout.tsx
+++ b/src/components/Layout/TestLayout.tsx
@@ -6,6 +6,7 @@ import { LeftSidebar } from './LeftSidebar';
 import { EnhancedMainEditor } from './EnhancedMainEditor';
 import { RightSidebar } from './RightSidebar';
 import { Resizable, ResizableHandle, ResizablePanel } from '../ui/resizable';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
 
 export function TestLayout() {
   const {
@@ -68,6 +69,9 @@ export function TestLayout() {
     setRightSidebarWidth(width);
   };
 
+  // 生成动态的 panel 布局 key，确保在侧边栏可见性改变时重新创建组件
+  const layoutKey = `${leftSidebarVisible ? 'L' : ''}${rightSidebarVisible ? 'R' : ''}`;
+
   const renderMainContent = () => {
     if (!leftSidebarVisible && !rightSidebarVisible) {
       return (
@@ -78,71 +82,57 @@ export function TestLayout() {
       );
     }
 
-    if (leftSidebarVisible && rightSidebarVisible) {
-      return (
-        <div className="flex flex-1">
-          <ActivityBar />
-          <div className="flex flex-1" ref={containerRef}>
-            <Resizable direction="horizontal" className="flex flex-1">
-              <ResizablePanel defaultSize={leftDefault} minSize={leftMin} maxSize={leftMax} onResize={onLeftResize}>
-                <LeftSidebar />
-              </ResizablePanel>
-              <ResizableHandle className="w-px bg-border" />
-              <ResizablePanel>
-                <EnhancedMainEditor />
-              </ResizablePanel>
-              <ResizableHandle className="w-px bg-border" />
-              <ResizablePanel defaultSize={rightDefault} minSize={rightMin} maxSize={rightMax} onResize={onRightResize}>
-                <RightSidebar />
-              </ResizablePanel>
-            </Resizable>
-          </div>
-        </div>
-      );
-    }
-
-    if (leftSidebarVisible) {
-      return (
-        <div className="flex flex-1">
-          <ActivityBar />
-          <div className="flex flex-1" ref={containerRef}>
-            <Resizable direction="horizontal" className="flex flex-1">
-              <ResizablePanel defaultSize={leftDefault} minSize={leftMin} maxSize={leftMax} onResize={onLeftResize}>
-                <LeftSidebar />
-              </ResizablePanel>
-              <ResizableHandle className="w-px bg-border" />
-              <ResizablePanel>
-                <EnhancedMainEditor />
-              </ResizablePanel>
-            </Resizable>
-          </div>
-        </div>
-      );
-    }
-
-    if (rightSidebarVisible) {
-      return (
-        <div className="flex flex-1">
-          <ActivityBar />
-          <div className="flex flex-1" ref={containerRef}>
-            <Resizable direction="horizontal" className="flex flex-1">
-              <ResizablePanel>
-                <EnhancedMainEditor />
-              </ResizablePanel>
-              <ResizableHandle className="w-px bg-light-border dark:bg-dark-border" />
-              <ResizablePanel defaultSize={rightDefault} minSize={rightMin} maxSize={rightMax} onResize={onRightResize}>
-                <RightSidebar />
-              </ResizablePanel>
-            </Resizable>
-          </div>
-        </div>
-      );
-    }
-
+    // 使用单一的 Resizable 组件，通过 key 属性强制重新创建
     return (
       <div className="flex flex-1">
         <ActivityBar />
-        <EnhancedMainEditor />
+        <div className="flex flex-1" ref={containerRef}>
+          <Resizable 
+            direction="horizontal" 
+            className="flex flex-1"
+            key={layoutKey}
+            id={`layout-${layoutKey}`}
+          >
+            {leftSidebarVisible && (
+              <>
+                <ResizablePanel 
+                  id="left-sidebar"
+                  order={1}
+                  defaultSize={leftDefault} 
+                  minSize={leftMin} 
+                  maxSize={leftMax} 
+                  onResize={onLeftResize}
+                >
+                  <LeftSidebar />
+                </ResizablePanel>
+                <ResizableHandle className="w-px bg-border" />
+              </>
+            )}
+            
+            <ResizablePanel 
+              id="main-editor"
+              order={2}
+            >
+              <EnhancedMainEditor />
+            </ResizablePanel>
+            
+            {rightSidebarVisible && (
+              <>
+                <ResizableHandle className="w-px bg-border" />
+                <ResizablePanel 
+                  id="right-sidebar"
+                  order={3}
+                  defaultSize={rightDefault} 
+                  minSize={rightMin} 
+                  maxSize={rightMax} 
+                  onResize={onRightResize}
+                >
+                  <RightSidebar />
+                </ResizablePanel>
+              </>
+            )}
+          </Resizable>
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix 'Panel data not found' error when closing sidebars by refactoring `ResizablePanel` rendering.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error "Panel data not found for index 2" occurred because `react-resizable-panels` struggled with dynamic changes in the number of panels, leading to incorrect index access. The fix addresses this by using a dynamic `key` for the `Resizable` component to force re-creation on layout changes, and by adding explicit `id` and `order` props to `ResizablePanel` components to improve their stable identification and rendering order. This ensures the library correctly tracks panels even when their visibility changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-396825d0-cc5b-46ca-921d-aaf3c0cd5631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-396825d0-cc5b-46ca-921d-aaf3c0cd5631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

